### PR TITLE
Fix error where s3 module couldn't be used

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,23 +38,42 @@
 
 # If the app's JAR is in S3, grab it from there.
 - block:
-    - name: Install boto
+    ##
+    # Unfortunately, we can't use Ansible's aws_s3 module here, as some of its
+    # dependencies (e.g. boto3) aren't available via yum.
+    ##
+    - name: Install Prerequisites
       yum:
         name: "{{ item }}"
-        state: latest
+        state: present
       with_items:
-        # Needed to use the `s3` module.
-        - python-boto
+        - unzip
       become: true
-    - name: Copy Pipeline Application
-      s3:
-        mode: get
-        bucket: "{{ data_pipeline_appjar_s3_bucket }}"
-        object: "{{ item }}"
-        dest: "{{ data_pipeline_dir }}/{{ item }}"
+    - name: Download AWS CLI Bundled Installer
+      get_url:
+        url: 'https://s3.amazonaws.com/aws-cli/awscli-bundle.zip'
+        dest: '/tmp/awscli-bundle.zip'
+        mode: 'u=r,g=,o='
+      become: true
+    - name: Extract AWS CLI Bundled Installer
+      unarchive:
+        src: '/tmp/awscli-bundle.zip'
+        dest: '/tmp'
+        remote_src: true
+        mode: 'u=rx,g=,o='
+      become: true
+    - name: Install the AWS CLI
+      command: '/tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws'
+      args:
+        creates: '/usr/local/bin/aws'
+      become: true
+    - name: Download Pipeline Application
+      command: /usr/local/bin/aws s3 cp "s3://{{ data_pipeline_appjar_s3_bucket }}/{{ item }}" "{{ data_pipeline_dir }}/{{ item }}"
+      args:
+        creates: "{{ data_pipeline_dir }}/{{ item }}"
+      become: true
       with_items:
         - "{{ data_pipeline_appjar_name }}"
-      become: true
       notify:
         - 'Restart Pipeline Service'
   when: data_pipeline_appjar_s3_bucket is defined


### PR DESCRIPTION
Problem only appears when running Ansible 2.4+ and RHEL 7. Ansible added some new dependencies to the module that just aren't available on RHEL 7.

https://issues.hhsdevcloud.us/browse/CBBI-128