### PR TITLE
Have service wait for networking before starting.

### DIFF
--- a/templates/bluebutton-data-pipeline.service.j2
+++ b/templates/bluebutton-data-pipeline.service.j2
@@ -1,5 +1,7 @@
 [Unit]
 Description=Blue Button Data Pipeline Service
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 WorkingDirectory={{ data_pipeline_dir }}


### PR DESCRIPTION
It wasn't doing this before, which was causing it to fail when the system was rebooting, as it was coming up too early and couldn't access the network.

https://issues.hhsdevcloud.us/browse/CBBD-402