### PR TITLE
BLUEBUTTON-799: Don't force `yum upgrade`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Install Pre-requisites
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items:
     # Needed to run the ETL service.
     - java-1.8.0-openjdk
@@ -128,4 +128,3 @@
   notify:
     - 'Enable Pipeline Service'
     - 'Restart Pipeline Service'
-


### PR DESCRIPTION
It's not a bad idea, in general, but it's also a risky process and so should be run only when specifically needed.

https://jira.cms.gov/browse/BLUEBUTTON-799